### PR TITLE
Fix some bugs with self transition

### DIFF
--- a/examples/try.html
+++ b/examples/try.html
@@ -19,6 +19,11 @@ seqdiag {
 	B -&gt; C [label = "B to C"];
 	C --&gt; B [label = "C to B"];
 	B --&gt; A [label = " return to A"];
+	A --&gt; A [label = " self transition on A"];
+	B --&gt; B [label = " self transition on B"];
+	D --&gt; D [label = " self transition on D"];
+	C --&gt; C [label = " self transition on C"];
+
 }
 		</textarea></div>
 		<input id="submit-preview" type="submit" value="preview">

--- a/lib/seqdiag.js
+++ b/lib/seqdiag.js
@@ -420,12 +420,7 @@
         }
         var nextNodeRect = this.getNodeRect(nextNode.id);
         var fromX   = parseInt(target.getAttribute("x")) + parseInt(target.getAttribute("width")) / 2.0;
-        var toX   = parseInt(nextNodeRect.getAttribute("x")) + parseInt(nextNodeRect.getAttribute("width")) / 2.0;
-        if ( fromX < toX ) {
-            toX = fromX + ( toX - fromX ) / 2;
-        } else {
-            toX = fromX + ( fromX - toX ) / 2;
-        }
+        var toX = fromX + this.svg.width.baseVal.value / nodes.length / 2
 
         var fromPath = this.createSVGElement("path");
         fromPath.setAttribute("stroke", this.defaultStrokeColor);


### PR DESCRIPTION
Fix a bug with self transition: now self transition takes half of a row width; In the 'Try Seqdiag.js' example, a self transition on B is not anymore empty.
